### PR TITLE
Fix portal owners not beeing able to destroy their own portals

### DIFF
--- a/net/cpprograms/minecraft/TravelPortals/TravelPortalsBlockListener.java
+++ b/net/cpprograms/minecraft/TravelPortals/TravelPortalsBlockListener.java
@@ -150,7 +150,7 @@ public class TravelPortalsBlockListener implements Listener {
 							event.setCancelled(true);
 							return;
 						}
-						if (!w.getOwner().equals("") && !w.getOwner().equals(player)) {
+						if (!w.getOwner().equals("") && !w.getOwner().equals(player.getName())) {
 							if (!plugin.permissions.hasPermission(event.getPlayer(), "travelportals.admin.portal.destroy")) {
 								event.setCancelled(true);
 								return;


### PR DESCRIPTION
After enabling permissions support I noticed that portal owners can no longer destroy their own portals even when they have the travelportals.portal.destroy permission. Turns out the owner's name was being compared to the whole player object and not just the player's name.