### PR TITLE
Fix location polling when useplayermove is false on 1.9+

### DIFF
--- a/net/cpprograms/minecraft/TravelPortals/PortalUseTask.java
+++ b/net/cpprograms/minecraft/TravelPortals/PortalUseTask.java
@@ -98,10 +98,9 @@ public class PortalUseTask implements Runnable {
 			return;
 
 		Server server = Bukkit.getServer();
-		Player[] players = server.getOnlinePlayers();
 		int n = 0; // cleanup heuristic (if 0 , can clear map of lastDestinations).
 
-		for (Player player : players)
+		for (Player player : server.getOnlinePlayers())
 		{
 			int w = isInPortal(player);
 			String playerName = player.getName();


### PR DESCRIPTION
Oops, forgot to pr that in. This just fixes the issue were the position pollsing isn't working when disabling the `useplayermove` option because Bukkit#getOnlinePlayers returns a Collection and not an Array after 1.9.