### PR TITLE
Adds ability to limit the creation of portals

### DIFF
--- a/src/main/java/net/cpprograms/minecraft/General/PermissionsHandler.java
+++ b/src/main/java/net/cpprograms/minecraft/General/PermissionsHandler.java
@@ -1,6 +1,8 @@
 package net.cpprograms.minecraft.General;
 
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
 
 /**
  * Handle permissions stuff, if needed.
@@ -51,5 +53,33 @@ public class PermissionsHandler
 	public boolean hasPermission(CommandSender sender, String permission)
 	{
 		return hasPermission(sender, permission, true);
+	}
+
+	/**
+	 * Get the value of a numeric permission
+	 * @param sender The player
+	 * @param permission The permission
+	 * @return The numeric value if it is set, otherwise 0
+	 */
+	public int getNumVal(CommandSender sender, String permission)
+	{
+		if (!permission.endsWith("."))
+			permission = permission + ".";
+
+		int partsNum = permission.split("\\.").length;
+		for(PermissionAttachmentInfo perm: ((Player)sender).getEffectivePermissions()){
+			String permString = perm.getPermission();
+			if(permString.startsWith(permission)){
+				String[] amount = permString.split("\\.");
+				if (amount.length == (partsNum +1)) {
+					try {
+						return Integer.parseInt(amount[amount.length - 1]);
+					} catch (Exception ex) {
+						// Nothing to do
+					}
+				}
+			}
+		}
+		return 0;
 	}
 }

--- a/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortals.java
+++ b/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortals.java
@@ -168,6 +168,11 @@ public class TravelPortals extends PluginBase {
 	 */
 	private PortalUseTask useTask = null;
 
+	/**
+	 * Should the max-portals permission apply per world?
+	 */
+	protected Boolean maxportalsperworld = false;
+
 
 	/**
 	 * Called upon enabling the plugin
@@ -286,6 +291,8 @@ public class TravelPortals extends PluginBase {
 				mainTicks = conf.getInt("polling-mainticks");
 			if (conf.get("polling-followticks", null) != null)
 				followTicks = conf.getInt("polling-followticks");
+			if (conf.get("maxportalsperworld", null) != null)
+				maxportalsperworld = conf.getBoolean("maxportalsperworld");
 
 		} catch (NumberFormatException i) {
 			logSevere("An exception occurred when trying to read your config file. " + i.getMessage());

--- a/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortals.java
+++ b/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortals.java
@@ -171,7 +171,7 @@ public class TravelPortals extends PluginBase {
 	/**
 	 * Should the max-portals permission apply per world?
 	 */
-	protected Boolean maxportalsperworld = false;
+	protected boolean maxportalsperworld = false;
 
 
 	/**

--- a/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortalsBlockListener.java
+++ b/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortalsBlockListener.java
@@ -54,11 +54,9 @@ public class TravelPortalsBlockListener implements Listener {
 				maxPortals = plugin.permissions.getNumVal(event.getPlayer(), "travelportals.portal.create");
 
 				// Count current portals of user
-				currPortalsNum = (int) plugin.getPortalStorage().getPortals().values()
-						.stream()
-						.filter(p -> p.isOwner(player))
-						.filter(p -> plugin.maxportalsperworld ? p.getWorld() == event.getBlock().getWorld().getName() : true)
-						.count();
+				currPortalsNum = plugin.maxportalsperworld
+						? plugin.getPortalStorage().getPlayerPortalsForWorld(player, event.getBlock().getWorld()).size()
+						: plugin.getPortalStorage().getPlayerPortals(player).size();
 			}
 
 			// Test the area to the right of the portal

--- a/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortalsBlockListener.java
+++ b/src/main/java/net/cpprograms/minecraft/TravelPortals/TravelPortalsBlockListener.java
@@ -38,12 +38,23 @@ public class TravelPortalsBlockListener implements Listener {
 		{
 			if (!plugin.permissions.hasPermission(event.getPlayer(), "travelportals.portal.create"))
 				return;
+
 			Player player = event.getPlayer();
 			int numwalls = 0;
 			int x = event.getBlock().getX();
 			int y = event.getBlock().getY();
 			int z = event.getBlock().getZ();
 			int doordir = 0;
+
+			// Check how many portals the user may create
+			int maxPortals = plugin.permissions.getNumVal(event.getPlayer(), "travelportals.portal.create");
+
+			// Count current portals of user
+			int currPortalsNum = (int)plugin.getPortalStorage().getPortals().values()
+					.stream()
+					.filter(p -> p.isOwner(player))
+					.filter(p -> plugin.maxportalsperworld ? p.getWorld() == event.getBlock().getWorld().getName() : true)
+					.count();
 
 			// Test the area to the right of the portal
 			if (player.getWorld().getBlockAt(x + 1, y, z).getType() == plugin.blocktype &&
@@ -101,6 +112,11 @@ public class TravelPortalsBlockListener implements Listener {
 			// This is what we want. (x, y-1, z) is the coordinate above the torch, and needs to be empty.
 			if (numwalls == 13 && player.getWorld().getBlockAt(x, y+1, z).getType() == Material.AIR)
 			{
+				if (currPortalsNum >= maxPortals) {
+					player.sendMessage(ChatColor.DARK_RED + "You've reached your portal limit and can't create new portals.");
+					return;
+				}
+
 				player.getWorld().getBlockAt(x, y, z).setType(plugin.portaltype);
 				player.getWorld().getBlockAt(x, y+1, z).setType(plugin.portaltype);
 
@@ -108,6 +124,7 @@ public class TravelPortalsBlockListener implements Listener {
 					event.getBlock().getWorld().playSound(event.getBlock().getLocation(), plugin.portalCreateSound, SoundCategory.BLOCKS, 1f, 1f);
 
 				player.sendMessage(ChatColor.DARK_RED + "You have created a portal! Type /portal help for help using it.");
+				player.sendMessage(ChatColor.DARK_RED + "You can build " + (maxPortals - ++currPortalsNum) + " more portals" );
 
 				WarpLocation portal = new WarpLocation(x,y,z, doordir, player.getWorld().getName(), player.getName());
 				plugin.getPortalStorage().addPortal(portal);

--- a/src/main/java/net/cpprograms/minecraft/TravelPortals/storage/PortalStorage.java
+++ b/src/main/java/net/cpprograms/minecraft/TravelPortals/storage/PortalStorage.java
@@ -4,6 +4,8 @@ import net.cpprograms.minecraft.General.uuidconverter.UuidConverter;
 import net.cpprograms.minecraft.TravelPortals.TravelPortals;
 import net.cpprograms.minecraft.TravelPortals.WarpLocation;
 import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -202,6 +204,32 @@ public abstract class PortalStorage {
             return closest;
         }
         return null;
+    }
+
+    /**
+     * Get all the portals of a specific player
+     * @param player The owner of the portals
+     * @return The portals or an empty collection of none were found
+     */
+    public Collection<WarpLocation> getPlayerPortals(Player player) {
+        return getPlayerPortalsForWorld(player, null);
+    }
+
+    /**
+     * Get all the portals of a specific player, in a specific world
+     * @param player The owner of the portals
+     * @param world The world to look for, or null for all worlds
+     * @return The portals or an empty collection of none were found
+     */
+    public Collection<WarpLocation> getPlayerPortalsForWorld(Player player, World world) {
+        Set<WarpLocation> playerPortals = new HashSet<>();
+
+        for (Map.Entry<String, WarpLocation> portal : portals.entrySet()) {
+            if (portal.getValue().isOwner(player) && (world == null || portal.getValue().getWorld().equals(world.getName())))
+                playerPortals.add(portal.getValue());
+        }
+
+        return playerPortals;
     }
 
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -87,3 +87,6 @@ polling-followticks: 17
 # the output from it can make diagnosing problems easier, and if you are going to report
 # a bug, you will likely be asked to turn this on and reproduce the problem.
 debug: false
+
+# Whether or not the max-portals permission applies on a 'per world' basis or not
+maxportalsperworld: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -36,7 +36,7 @@ permissions:
     description: User permissions that work like classic TravelPortals; all users have access to all portals.
     children: 
       travelportals.portal.create: true
-      travelportals.portal.create.250: true
+      travelportals.portal.create.nolimit: true
       travelportals.portal.use: true
       travelportals.portal.destroy: true
       travelportals.command.help: true
@@ -57,7 +57,7 @@ permissions:
     description: User permissions that limit each user to their own portals
     children: 
       travelportals.portal.create: true
-      travelportals.portal.create.250: true
+      travelportals.portal.create.nolimit: true
       travelportals.portal.use: true
       travelportals.portal.destroy: true
       travelportals.command.help: true
@@ -71,7 +71,7 @@ permissions:
     description: Suggested permissions for ops. Gives access to most commands
     children:
       travelportals.portal.create: true
-      travelportals.portal.create.250: true
+      travelportals.portal.create.nolimit: true
       travelportals.portal.use: true
       travelportals.portal.use.crossworld: true
       travelportals.portal.destroy: true
@@ -97,7 +97,7 @@ permissions:
     description: Gives access to everything. Use with caution.
     children: 
       travelportals.portal.create: true
-      travelportals.portal.create.9999: true
+      travelportals.portal.create.nolimit: true
       travelportals.portal.use: true
       travelportals.portal.use.crossworld: true
       travelportals.portal.destroy: true
@@ -133,6 +133,9 @@ permissions:
     default: true
   travelportals.portal.create.250:
     description: Max portals a user may create
+    default: true
+  travelportals.portal.create.nolimit:
+    description: Allows the user to build as many portals as they like
     default: true
   travelportals.portal.use:
     description: Allows the user to use his/her own portals.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -36,6 +36,7 @@ permissions:
     description: User permissions that work like classic TravelPortals; all users have access to all portals.
     children: 
       travelportals.portal.create: true
+      travelportals.portal.create.250: true
       travelportals.portal.use: true
       travelportals.portal.destroy: true
       travelportals.command.help: true
@@ -56,6 +57,7 @@ permissions:
     description: User permissions that limit each user to their own portals
     children: 
       travelportals.portal.create: true
+      travelportals.portal.create.250: true
       travelportals.portal.use: true
       travelportals.portal.destroy: true
       travelportals.command.help: true
@@ -69,6 +71,7 @@ permissions:
     description: Suggested permissions for ops. Gives access to most commands
     children:
       travelportals.portal.create: true
+      travelportals.portal.create.250: true
       travelportals.portal.use: true
       travelportals.portal.use.crossworld: true
       travelportals.portal.destroy: true
@@ -94,6 +97,7 @@ permissions:
     description: Gives access to everything. Use with caution.
     children: 
       travelportals.portal.create: true
+      travelportals.portal.create.9999: true
       travelportals.portal.use: true
       travelportals.portal.use.crossworld: true
       travelportals.portal.destroy: true
@@ -126,6 +130,9 @@ permissions:
   # Here be real permissions
   travelportals.portal.create:
     description: Allows the user to create portals.
+    default: true
+  travelportals.portal.create.250:
+    description: Max portals a user may create
     default: true
   travelportals.portal.use:
     description: Allows the user to use his/her own portals.


### PR DESCRIPTION
I wanted to limit the creation of portals by my players.
Changes in this PR:

1.  Adds a new permission: 
`travelportals.portal.create.250`
Which allows to set a limit on a permission basis. (Simply change the number)
2. Adds a new config entry:
`maxportalsperworld: false`
When set to true, the limit set by the permission applies on a per world basis.



